### PR TITLE
Fix and refine docker testing suite

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 * Setup flow for CentOS OVPN server
 * Playbook for revoking of client
   * Add testing of revoking including connection
+* Setup automatic testing
 
 ## Extras
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 * Setup flow for CentOS OVPN server
 * Playbook for revoking of client
   * Add testing of revoking including connection
-* Add steps for setting up new SSH key for testing
 
 ## Extras
 

--- a/playbooks/roles/add_client/tasks/generate-keypair.yml
+++ b/playbooks/roles/add_client/tasks/generate-keypair.yml
@@ -1,6 +1,6 @@
 ---
 - name: generate-keypair |> Generate client request
-  command: ./easyrsa gen-req {{ client_name }} nopass
+  command: ./easyrsa gen-req "{{ client_name }}" nopass
   args:
     chdir: "{{ easyrsa_path }}"
     creates: "{{ easyrsa_client_key }}"

--- a/playbooks/roles/openvpn/tasks/config-ovpn.yml
+++ b/playbooks/roles/openvpn/tasks/config-ovpn.yml
@@ -1,8 +1,11 @@
 ---
 - name: config-ovpn |> Enable IPv4 traffic forwarding
+  vars:
+    env_container: "{{ lookup('env', 'CONTAINER') }}"
   sysctl:
     name: net.ipv4.ip_forward
     value: '1'
+  when: env_container is undefined
 
 - name: config-ovpn |> Create client configuration directory
   file:

--- a/playbooks/roles/openvpn/tasks/firewall-Debian.yml
+++ b/playbooks/roles/openvpn/tasks/firewall-Debian.yml
@@ -1,4 +1,7 @@
 ---
+- name: firewall-Debian |> Refresh facts
+  setup: # VSCode language server complains - blah blah
+
 - name: firewall-Debian |> Move UFW template to /etc/ufw/before.rules.ovpn
   template:
     src: etc_ufw_before.rules.j2

--- a/tests/docker/Dockerfile.centos8
+++ b/tests/docker/Dockerfile.centos8
@@ -1,24 +1,26 @@
 FROM centos:8
 
+ENV CONTAINER=docker
+
 # update system
-RUN yum update -y \
- && yum clean all
+RUN dnf update -y \
+    && dnf clean all
 
 # install necessary packages
-RUN yum install -y sudo openssh-server openssh-clients \
+RUN dnf install -y sudo openssh-server openssh-clients \
     python3 ca-certificates
 
-# create user used for ssh'ing
+# create user used for ssh
 RUN useradd -m -G wheel -s /bin/bash docker \
- && echo "docker:rekcod" | chpasswd
+    && echo "docker:rekcod" | chpasswd
 
 # setup ssh with authorized_keys
 RUN mkdir /home/docker/.ssh
 COPY tests/id_rsa.pub /home/docker/.ssh/authorized_keys
-RUN chown -R docker:docker /home/docker/.ssh/ && \
-    chmod 701 /home/docker && \
-    chmod 700 /home/docker/.ssh && \
-    chmod 600 /home/docker/.ssh/authorized_keys
+RUN chown -R docker:docker /home/docker/.ssh/ \
+    && chmod 701 /home/docker \
+    && chmod 700 /home/docker/.ssh \
+    && chmod 600 /home/docker/.ssh/authorized_keys
 
 # expose port 22 for ssh
 EXPOSE 22

--- a/tests/docker/Dockerfile.client.debian10
+++ b/tests/docker/Dockerfile.client.debian10
@@ -1,33 +1,6 @@
-FROM debian:10.4-slim
-
-ENV CONTAINER=docker
-
-# update system
-RUN apt-get update \
-    && apt-get upgrade -y
-
-# install necessary packages
-RUN DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -q -y \
-        sudo openssh-server openssh-client \
-        ca-certificates openvpn python3-minimal
-
-# create user to be used for ssh
-RUN useradd -m -G sudo -s /bin/bash docker \
-    && echo "docker:rekcod" | chpasswd
-
-# setup ssh with authorized_keys
-RUN mkdir /home/docker/.ssh
-COPY tests/id_rsa.pub /home/docker/.ssh/authorized_keys
-RUN chown -R docker:docker /home/docker/.ssh/ \
-    && chmod 701 /home/docker \
-    && chmod 700 /home/docker/.ssh \
-    && chmod 600 /home/docker/.ssh/authorized_keys
+FROM ansible-ovpn-infra/debian:10.4
 
 # copy openvpn config file
 COPY tests/testuser.ovpn /etc/openvpn/testuser.conf
-
-# expose port 22 for ssh
-EXPOSE 22
 
 CMD ["/sbin/init"]

--- a/tests/docker/Dockerfile.client.debian10
+++ b/tests/docker/Dockerfile.client.debian10
@@ -1,25 +1,30 @@
-FROM debian:10.4
+FROM debian:10.4-slim
+
+ENV CONTAINER=docker
 
 # update system
-RUN apt-get update && apt-get upgrade -y
+RUN apt-get update \
+    && apt-get upgrade -y
 
 # install necessary packages
 RUN DEBIAN_FRONTEND=noninteractive \
- && apt-get install -q -y sudo openssh-server openssh-client \
-    ca-certificates openvpn python3-minimal
+    && apt-get install -q -y \
+        sudo openssh-server openssh-client \
+        ca-certificates openvpn python3-minimal
 
-# create user to be used for ssh'ing
+# create user to be used for ssh
 RUN useradd -m -G sudo -s /bin/bash docker \
- && echo "docker:rekcod" | chpasswd
+    && echo "docker:rekcod" | chpasswd
 
 # setup ssh with authorized_keys
 RUN mkdir /home/docker/.ssh
 COPY tests/id_rsa.pub /home/docker/.ssh/authorized_keys
 RUN chown -R docker:docker /home/docker/.ssh/ \
- && chmod 701 /home/docker \
- && chmod 700 /home/docker/.ssh \
- && chmod 600 /home/docker/.ssh/authorized_keys
+    && chmod 701 /home/docker \
+    && chmod 700 /home/docker/.ssh \
+    && chmod 600 /home/docker/.ssh/authorized_keys
 
+# copy openvpn config file
 COPY tests/testuser.ovpn /etc/openvpn/testuser.conf
 
 # expose port 22 for ssh

--- a/tests/docker/Dockerfile.debian10
+++ b/tests/docker/Dockerfile.debian10
@@ -6,11 +6,13 @@ ENV CONTAINER=docker
 RUN apt-get update \
     && apt-get upgrade -y
 
-# install necessary packages
+# install necessary packages (openssh, sudo and python3)
+# and packages to speed process (openvpn and ping)
 RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get install -q -y \
         sudo openssh-server openssh-client \
-        ca-certificates openvpn python3-minimal
+        ca-certificates openvpn python3-minimal \
+        iputils-ping
 
 # create user to be used for ssh
 RUN useradd -m -G sudo -s /bin/bash docker \

--- a/tests/docker/Dockerfile.debian10
+++ b/tests/docker/Dockerfile.debian10
@@ -1,24 +1,28 @@
-FROM debian:10.4
+FROM debian:10.4-slim
+
+ENV CONTAINER=docker
 
 # update system
-RUN apt-get update && apt-get upgrade -y
+RUN apt-get update \
+    && apt-get upgrade -y
 
 # install necessary packages
 RUN DEBIAN_FRONTEND=noninteractive \
- && apt-get install -q -y sudo openssh-server openssh-client \
-    python3-minimal ca-certificates
+    && apt-get install -q -y \
+        sudo openssh-server openssh-client \
+        ca-certificates openvpn python3-minimal
 
-# create user to be used for ssh'ing
+# create user to be used for ssh
 RUN useradd -m -G sudo -s /bin/bash docker \
- && echo "docker:rekcod" | chpasswd
+    && echo "docker:rekcod" | chpasswd
 
 # setup ssh with authorized_keys
 RUN mkdir /home/docker/.ssh
 COPY tests/id_rsa.pub /home/docker/.ssh/authorized_keys
 RUN chown -R docker:docker /home/docker/.ssh/ \
- && chmod 701 /home/docker \
- && chmod 700 /home/docker/.ssh \
- && chmod 600 /home/docker/.ssh/authorized_keys
+    && chmod 701 /home/docker \
+    && chmod 700 /home/docker/.ssh \
+    && chmod 600 /home/docker/.ssh/authorized_keys
 
 # expose port 22 for ssh
 EXPOSE 22

--- a/tests/run-client-container.sh
+++ b/tests/run-client-container.sh
@@ -5,8 +5,7 @@ set -e
 RUN_OPTS="-d --cap-add=NET_ADMIN --device=/dev/net/tun --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 setup_container() {
-  ssh_port=$(shuf -i 22222-44444 -n 1)
-  container_id=$(docker run ${RUN_OPTS} -p $ssh_port:22 --name $3 ansible-ovpn-infra/$1:$2)
+  container_id=$(docker run ${RUN_OPTS} --name $3 ansible-ovpn-infra/$1:$2)
   container_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${container_id})
 
   echo "$3 ansible_host=$container_ip ansible_user=docker"

--- a/tests/run-client-container.sh
+++ b/tests/run-client-container.sh
@@ -2,10 +2,11 @@
 
 set -e
 
-RUN_OPTS="-d --privileged"
+RUN_OPTS="-d --cap-add=NET_ADMIN --device=/dev/net/tun --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 setup_container() {
-  container_id=$(docker run ${RUN_OPTS} --name $3 ansible-ovpn-infra/$1:$2)
+  ssh_port=$(shuf -i 22222-44444 -n 1)
+  container_id=$(docker run ${RUN_OPTS} -p $ssh_port:22 --name $3 ansible-ovpn-infra/$1:$2)
   container_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${container_id})
 
   echo "$3 ansible_host=$container_ip ansible_user=docker"

--- a/tests/run-containers.sh
+++ b/tests/run-containers.sh
@@ -6,7 +6,7 @@ RUN_OPTS="-d --cap-add=NET_ADMIN --device=/dev/net/tun --tmpfs /run --tmpfs /run
 CA_DISTRIBUTION="${CA_DISTRIBUTION:-centos}"
 CA_VERSION="${CA_VERSION:-8}"
 OVPN_DISTRIBUTION="${OVPN_DISTRIBUTION:-debian}"
-OVPN_VERSION="${OPVN_VERSION:-10.4}"
+OVPN_VERSION="${OVPN_VERSION:-10.4}"
 
 setup_container() {
   container_id=$(docker run ${RUN_OPTS} --name $3 ansible-ovpn-infra/$1:$2)
@@ -16,7 +16,7 @@ setup_container() {
 }
 
 ca_container=$(setup_container $CA_DISTRIBUTION $CA_VERSION "ca")
-ovpn_container=$(setup_container $OVPN_DISTRIBUTION $OPVN_VERSION "ovpn")
+ovpn_container=$(setup_container $OVPN_DISTRIBUTION $OVPN_VERSION "ovpn")
 
 # replace ${} parameters in template file
 sed -e 's/${ca_docker}/'"$ca_container"'/g' -e 's/${openvpn_docker}/'"$ovpn_container"'/g' tests/docker_hosts.template > tests/docker_hosts

--- a/tests/run-containers.sh
+++ b/tests/run-containers.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-RUN_OPTS="-d --privileged"
+RUN_OPTS="-d --cap-add=NET_ADMIN --device=/dev/net/tun --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro"
 CA_DISTRIBUTION="${CA_DISTRIBUTION:-centos}"
 CA_VERSION="${CA_VERSION:-8}"
-OPVN_DISTRIBUTION="${OPVN_DISTRIBUTION:-debian}"
-OPVN_VERSION="${OPVN_VERSION:-10.4}"
+OVPN_DISTRIBUTION="${OVPN_DISTRIBUTION:-debian}"
+OVPN_VERSION="${OPVN_VERSION:-10.4}"
 
 setup_container() {
   container_id=$(docker run ${RUN_OPTS} --name $3 ansible-ovpn-infra/$1:$2)
@@ -16,7 +16,7 @@ setup_container() {
 }
 
 ca_container=$(setup_container $CA_DISTRIBUTION $CA_VERSION "ca")
-ovpn_container=$(setup_container $OPVN_DISTRIBUTION $OPVN_VERSION "ovpn")
+ovpn_container=$(setup_container $OVPN_DISTRIBUTION $OPVN_VERSION "ovpn")
 
 # replace ${} parameters in template file
 sed -e 's/${ca_docker}/'"$ca_container"'/g' -e 's/${openvpn_docker}/'"$ovpn_container"'/g' tests/docker_hosts.template > tests/docker_hosts


### PR DESCRIPTION
* Update README with information on testing using new/existing SSH keys
* Update TODO with automatic testing point
* Update README with why `--privileged` was dropped
* Fix indention in Dockerfiles. Make use of `ansible-ovpn-infra/debian:10.4` in client image
* Add check when updating `sysctl` - `sysctl` does not run in container due to "read only filesystem"
* Fix run options and typo in `run-*container.sh` files